### PR TITLE
Add option to allow Route in Menu Items

### DIFF
--- a/src/FilamentMenusPlugin.php
+++ b/src/FilamentMenusPlugin.php
@@ -19,6 +19,14 @@ class FilamentMenusPlugin implements Plugin
         return 'filament-menus';
     }
 
+    public static bool $allowRoute = true;
+
+    public function allowRoute(bool $condition = true): static
+    {
+        self::$allowRoute = $condition;
+        return $this;
+    }
+
     public function register(Panel $panel): void
     {
         if(class_exists(Module::class) && \Nwidart\Modules\Facades\Module::find('FilamentMenus')?->isEnabled()){

--- a/src/Resources/MenuResource/Relations/MenuItems.php
+++ b/src/Resources/MenuResource/Relations/MenuItems.php
@@ -91,7 +91,8 @@ class MenuItems extends RelationManager
                     ->deletable(false)
                     ->label(trans('filament-menus::messages.cols.item.title')),
                 Forms\Components\Toggle::make('is_route')
-                    ->default(true)
+                    ->hidden(!filament('filament-menus')::$allowRoute)
+                    ->default(false)
                     ->label(trans('filament-menus::messages.cols.item.is_route'))
                     ->required()
                     ->live(),
@@ -141,8 +142,7 @@ class MenuItems extends RelationManager
                     ])
                     ->label(trans('filament-menus::messages.cols.item.badge_color')),
                 IconPicker::make('icon')
-                    ->label(trans('filament-menus::messages.cols.item.icon'))
-                    ->required(),
+                    ->label(trans('filament-menus::messages.cols.item.icon')),
                 Forms\Components\Toggle::make('new_tab')
                     ->label(trans('filament-menus::messages.cols.item.target'))
                     ->required(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `allowRoute` property to enhance routing control.
	- Added a `badge_color` select field for improved customization.

- **Improvements**
	- Updated form schema for `MenuItems`, enhancing user experience with dynamic field visibility and requirements based on user input.
	- Adjusted the default behavior of the `is_route` toggle for better usability. 

These changes aim to provide users with more flexibility and a streamlined interface while managing menu items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->